### PR TITLE
ZCS-8014: Third party vulnerabilities in dom4j

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -8,7 +8,7 @@
   <dependency org="commons-cli" name="commons-cli" rev="1.2" />
   <dependency org="org.apache.httpcomponents" name="httpclient" rev="${httpclient.version}"/>
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="${httpclient.httpcore.version}"/>
-  <dependency org="dom4j" name="dom4j" rev="1.5.2" />
+  <dependency org="org.dom4j" name="dom4j" rev="${dom4j.version}" />
   <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="zimbra" name="zm-common" rev="latest.integration"/>


### PR DESCRIPTION
Issue: Third-party vulnerabilities in dom4j
Fix: Upgrade dom4j to the latest version

Related PRs:
zm-network-build/ivysettings-network.xml - Zimbra/zm-network-build#9
zm-zcs/ivysettings.xml - Zimbra/zm-zcs#9
Zimbra/zm-core-utils - Zimbra/zm-core-utils#68
Zimbra/zm-zcs-lib - Zimbra/zm-zcs-lib#62
Zm-mailbox - Zimbra/zm-mailbox#988
zm-xmbxsearch-store - Zimbra/zm-xmbxsearch-store#4
zm-license-store - Zimbra/zm-license-store#9
zm-ews-common - Zimbra/zm-ews-common#4
zm-hsm-store - Zimbra/zm-hsm-store#4
zm-bulkprovision-store - Zimbra/zm-bulkprovision-store#6
zm-voice-store - Zimbra/zm-voice-store#3
zm-ldap-utils-store - Zimbra/zm-ldap-utils-store#3
zm-taglib - Zimbra/zm-taglib#34
zm-ssdb-ephemeral-store - Zimbra/zm-ssdb-ephemeral-store#10
zm-sync-tools - #6
zm-saml-consumer-store - Zimbra/zm-saml-consumer-store#3
zm-archive-store - Zimbra/zm-archive-store#1
zm-oauth-social - Zimbra/zm-oauth-social#55
zm-ldap-utilities - Zimbra/zm-ldap-utilities#13
zm-nginx-lookup-store - Zimbra/zm-nginx-lookup-store#12
zm-network-store - Zimbra/zm-network-store#38
zm-gql-admin - Zimbra/zm-gql-admin#2
zm-gql - Zimbra/zm-gql#55
zm-network-gql - Zimbra/zm-network-gql#6
zm-voice-store - Zimbra/zm-voice-store#3

zm-voice-cisco-store - Zimbra/zm-voice-cisco-store#4
zm-twofactorauth-store - Zimbra/zm-twofactorauth-store#12
oauth2_datasources - Zimbra/oauth2_datasources#4
zm-openoffice-store - Zimbra/zm-openoffice-store#5
zm-ews-store - Zimbra/zm-ews-store#24
zm-convertd-store - Zimbra/zm-convertd-store#10
zm-backup-store - Zimbra/zm-backup-store#13
zm-sync-common - Zimbra/zm-sync-common#5
zm-smime-store - Zimbra/zm-smime-store#8
zm-license-tools - Zimbra/zm-license-tools#16
zm-sync-store - Zimbra/zm-sync-store#13
zm-certificate-manager-store - https://github.com/Zimbra/zm-certificate-manager-store/pull/10